### PR TITLE
Remove duplicated "Fishing" icon

### DIFF
--- a/resources/svg/Fishing.svg
+++ b/resources/svg/Fishing.svg
@@ -1,3 +1,0 @@
-<svg width="24" height="24" stroke-width="1.5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M16 7C17.1046 7 18 6.10457 18 5C18 3.89543 17.1046 3 16 3C14.8954 3 14 3.89543 14 5C14 6.10457 14.8954 7 16 7ZM16 7C16 7 16 13.0948 16 17C16 23 6 23 6 17V13L8 15" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>


### PR DESCRIPTION
The icon is duplicated and causing an the following issue while installing on Mac OS

```
The archive may contain identical file names with different capitalization (which fails on case insensitive filesystems) Unzip with unzip command failed, falling back to ZipArchive class
```